### PR TITLE
Default max-age to 86400

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Add the component to your HTML and configure it with appropriate data attributes
 | `data-gaw-level`             | Current carbon intensity level                        | `"low"`, `"moderate"`, `"high"`                        | `undefined` (shows as "Data unavailable") |
 | `data-gaw-location`          | Location code                                         | Alpha-2 country code or valid Electricity Maps Zone ID | `undefined` (shows as "Location unknown") |
 | `data-ignore-cookie`         | Name of the cookie used to store user preference      | Any valid cookie name                                  | `"gaw-ignore"`                            |
-| `data-ignore-cookie-max-age` | Max age for the ignore cookie                         | Valid cookie max-age or "Session"                      | `"Session"`                               |
+| `data-ignore-cookie-max-age` | Max age for the ignore cookie                         | Valid cookie max-age in milliseconds                   | `"84600"`                                 |
 | `data-learn-more-link`       | URL for the "Learn more" link in the info popover     | Any valid URL                                          | `"#"`                                     |
 | `data-popover-text`          | Custom text to display in the info popover            | Any string                                             | Default explanatory text                  |
 | `data-views`                 | Comma-separated list of design modes                  | String of comma-separated values                       | `"low,moderate,high"`                     |

--- a/src/gaw-info-bar.js
+++ b/src/gaw-info-bar.js
@@ -18,7 +18,7 @@ export class GawInfoBar extends LitElement {
     this.autoMode = true;
     this.gridLevelText = "Your local grid: Data unavailable";
     this.ignoreCookie = "gaw-ignore";
-    this.ignoreCookieMaxAge = "84600";
+    this.ignoreCookieMaxAge = "86400";
     this.manualVersion = "low";
     this.learnMoreLink = "#";
     this.defaultView = "low";

--- a/src/gaw-info-bar.js
+++ b/src/gaw-info-bar.js
@@ -18,7 +18,7 @@ export class GawInfoBar extends LitElement {
     this.autoMode = true;
     this.gridLevelText = "Your local grid: Data unavailable";
     this.ignoreCookie = "gaw-ignore";
-    this.ignoreCookieMaxAge = "Session";
+    this.ignoreCookieMaxAge = "84600";
     this.manualVersion = "low";
     this.learnMoreLink = "#";
     this.defaultView = "low";


### PR DESCRIPTION
Defaults the max-age for cookies set in the web component to 86400 milliseconds (24 hours).

This resolves #6 where stateful cookies were not being set in Safari and webkit due to the `max-age` being set as `"Session"`.